### PR TITLE
Fix most dead links.

### DIFF
--- a/docs/government/stockexchanges.md
+++ b/docs/government/stockexchanges.md
@@ -30,4 +30,4 @@ In addition, some private stock exchanges may charge fees on transferring or lim
 
 Listed and linked below are some of the Private Stock Exchanges on the server:
 
-1. [The Exchange](https://discord.gg/Ws7ke4Tjuy)
+1. [The Exchange](https://discord.gg/HufTG6Cf8m)

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -45,6 +45,8 @@ On joining the server, you start off with $500. While that's no small sum, you w
 - Real estate opportunities
 - Auctions
 
+You can learn more about making money by reading our guide on it [here](https://wiki.democracycraft.net/government/money/).
+
 ### Chest Shops
 
 ChestShops are where you can buy or sell materials from/to players and firms. To buy an item, right click on the sign, and to sell, left click on the sign. You can learn more about using them by reading our guide [here](https://wiki.democracycraft.net/features/chestshops/).

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -45,11 +45,9 @@ On joining the server, you start off with $500. While that's no small sum, you w
 - Real estate opportunities
 - Auctions
 
-You can learn more about making money by reading our guide on it [here](https://democracycraft.net/threads/making-money.1410/).
-
 ### Chest Shops
 
-ChestShops are where you can buy or sell materials from/to players and firms. To buy an item, right click on the sign, and to sell, left click on the sign. You can learn more about using them by reading our guide [here](https://democracycraft.net/threads/chest-shops.76/).
+ChestShops are where you can buy or sell materials from/to players and firms. To buy an item, right click on the sign, and to sell, left click on the sign. You can learn more about using them by reading our guide [here](https://wiki.democracycraft.net/features/chestshops/).
 
 
 ## Jobs and Exams
@@ -61,7 +59,7 @@ We have **three** main categories of jobs:
 - Professions - these jobs build on trade jobs by having more advanced or special perks. This could be specialised crafting recipes or plugin features. Not all professions will provide you with pay.
 - Government - you cannot get a Government job immediately, but after around 48 hours of in-game playtime a lot of players apply for these jobs on [our forums](https://www.democracycraft.net). These jobs provide a mix between trade and professions, allowing you to work in teams to better our nation!
 
-For more detailed information, read our [guide on jobs](https://democracycraft.net/threads/jobs.711/) and check out individual job guides that interest you [here](https://democracycraft.net/forums/job-guides.50/).
+For more detailed information, Check out individual job guides that interest you [here](https://wiki.democracycraft.net/category/jobs).
 
 ## Chat
 Our server is unique, as there are three chat channels you use to talk to other players. Please **read this carefully** as you will need to use these channels quite often!
@@ -69,7 +67,7 @@ Our server is unique, as there are three chat channels you use to talk to other 
 - Local (``/l``) - this is a channel with a 50 block radius. Only people within 50 blocks can read your messages (hear you!). Please use this when you are: talking to players right in front of you, seeking treatment from a Doctor, or in an event.
 - Private Messages (``/msg <username>``) - this allows you to have a one on one conversation with anyone. Replace ``<username>`` with whomever you want to talk to!
 
-In addition to these channel commands, you may want to learn some other handy commands. We recommend you visit [this guide](https://democracycraft.net/threads/commands.1264/) sometime after you finish this one!
+In addition to these channel commands, you may want to learn some other handy commands. We recommend you visit [this guide](https://wiki.democracycraft.net/tips-and-tricks/commands) sometime after you finish this one!
 
 ## Health
 

--- a/docs/jobs/professions/armourer.md
+++ b/docs/jobs/professions/armourer.md
@@ -26,11 +26,9 @@ To gather resources, you can either buy them from player shops or obtain them yo
 
 There are different ways to start earning money with your new profession:
 
-- Start your own store with chest shops using a rented store or a bought plot. You can sell firearms and ammo in a chest shop by finding their unique item id. For more information on how to set up a chest shop, check out the [Chest Shops Guide](https://www.democracycraft.net/threads/chest-shops.76/).
+- Start your own store with chest shops using a rented store or a bought plot. You can sell firearms and ammo in a chest shop by finding their unique item id. For more information on how to set up a chest shop, check out the [Chest Shops Guide](https://wiki.democracycraft.net/features/chestshops/).
 - Use the #marketplace channel to auction off your goods. You get to choose the starting price, and interested players can bid on your auctions.
-- Find a player-owned company to work for through the [DC Jobs server](https://discord.gg/Q8rNjddjjh). There may be employers hiring someone with your skills or profession!
-
-For more information, read this guide: [Guide - Making Money](https://democracycraft.net/threads/making-money.1410/).
+- Find a player-owned company to work for with the DC #employment channel: [DC Employment](https://discord.gg/democracy)
 
 ## Recipes
 

--- a/docs/jobs/professions/armourer.md
+++ b/docs/jobs/professions/armourer.md
@@ -29,12 +29,14 @@ There are different ways to start earning money with your new profession:
 - Start your own store with chest shops using a rented store or a bought plot. You can sell firearms and ammo in a chest shop by finding their unique item id. For more information on how to set up a chest shop, check out the [Chest Shops Guide](https://wiki.democracycraft.net/features/chestshops/).
 - Use the #marketplace channel to auction off your goods. You get to choose the starting price, and interested players can bid on your auctions.
 - Find a player-owned company to work for with the DC #employment channel: [DC Employment](https://discord.gg/democracy)
+- For more information, read this guide: [Guide - Making Money](https://wiki.democracycraft.net/government/money/).
 
 ## Recipes
 
 Here are a few armourer recipes to help you get started without the recipe book:
 
 You can find even more recipes through /ia under Guns.
+
 
 
 ![image](https://i.gyazo.com/6e50be5c71868e7c3cfc4e72f04d1c99.png)

--- a/docs/jobs/professions/lawyer.md
+++ b/docs/jobs/professions/lawyer.md
@@ -32,7 +32,7 @@ Commands:
 - [Introduction to the Courts](https://www.democracycraft.net/threads/introduction-to-the-courts.6629/)
 - [Courthouse Forum](https://democracycraft.net/forums/court.19/)
 - [Judicial Standards Act](https://www.democracycraft.net/threads/judicial-standards-act.5868/)
-- [Legal Board Discord (RBA)](https://discord.gg/U6gtx7Kqbh)
+- [Legal Board Discord (RBA)](https://discord.gg/u7KVfYB4Rt)
 
 ![Image](https://i.imgur.com/mRJnmC6.jpeg)
 
@@ -40,6 +40,4 @@ Commands:
 
 It's recommended that you purchase a plot and build a store or rent a shop to sell your services in. You can offer to represent players in court as a professional lawyer!
 
-For more info, read this guide! [Guide - Making Money](https://democracycraft.net/threads/making-money.1410/)
-
-You can find a firm to work for with DC Jobs: [DC Jobs](https://discord.gg/Q8rNjddjjh)
+You can find a firm to work for with the DC #employment channel: [DC Employment](https://discord.gg/democracy)

--- a/docs/jobs/professions/lawyer.md
+++ b/docs/jobs/professions/lawyer.md
@@ -40,4 +40,6 @@ Commands:
 
 It's recommended that you purchase a plot and build a store or rent a shop to sell your services in. You can offer to represent players in court as a professional lawyer!
 
+For more info, read this guide! [Guide - Making Money](https://wiki.democracycraft.net/government/money/)
+
 You can find a firm to work for with the DC #employment channel: [DC Employment](https://discord.gg/democracy)

--- a/docs/jobs/professions/pharmacist.md
+++ b/docs/jobs/professions/pharmacist.md
@@ -49,3 +49,5 @@ To gather resources, you can either buy them from player shops or collect them i
 ![Wild Starting Locations](https://i.imgur.com/HGY905O.png)
 
 (Check `/map` if you're looking for a specific biome).
+
+For more information, read this guide: [Guide - Making Money](https://wiki.democracycraft.net/government/money/)

--- a/docs/jobs/professions/pharmacist.md
+++ b/docs/jobs/professions/pharmacist.md
@@ -49,5 +49,3 @@ To gather resources, you can either buy them from player shops or collect them i
 ![Wild Starting Locations](https://i.imgur.com/HGY905O.png)
 
 (Check `/map` if you're looking for a specific biome).
-
-For more information, read this guide: [Guide - Making Money](https://democracycraft.net/threads/making-money.1410/)

--- a/docs/jobs/professions/realtor.md
+++ b/docs/jobs/professions/realtor.md
@@ -65,8 +65,6 @@ If real estate and sales are your forte, then look no further! This job is highl
 
 It's recommended that you purchase a plot and build a store, or rent a shop to sell your products in!
 
-Buy and sell property. You can list it under #realty-adverts on Discord!
+Buy and sell property. You can list it under #realestate on Discord!
 
-For more info, read this guide! [Guide - Making Money](https://democracycraft.net/threads/making-money.1410/)
-
-You can find a company to work for with DC Jobs: [DC Jobs](https://discord.gg/Q8rNjddjjh)
+- Find a player-owned company to work for with the DC #employment channel: [DC Employment](https://discord.gg/democracy)

--- a/docs/jobs/professions/realtor.md
+++ b/docs/jobs/professions/realtor.md
@@ -67,4 +67,5 @@ It's recommended that you purchase a plot and build a store, or rent a shop to s
 
 Buy and sell property. You can list it under #realestate on Discord!
 
+- For more info, read this guide! [Guide - Making Money](https://wiki.democracycraft.net/government/money/)
 - Find a player-owned company to work for with the DC #employment channel: [DC Employment](https://discord.gg/democracy)

--- a/docs/jobs/trades/accountant.md
+++ b/docs/jobs/trades/accountant.md
@@ -208,6 +208,4 @@ So, gather your resources, refine your accounting skills, and set forth on this 
 ## Passed the Exam? Now What?
 It is recommended that you get the Entrepreneur guide and register a business on the Business Portal subforum or look for a company who is in need of one of the above accountant roles!
 
-For more info, read the [Making Money Guide](https://democracycraft.net/threads/making-money.1410/).
-
-You can find a company to work for with DC Jobs: [Join the DC Jobs Discord here.](https://discord.gg/Q8rNjddjjh)
+- Find a player-owned company to work for with the DC #employment channel: [DC Employment](https://discord.gg/democracy)

--- a/docs/jobs/trades/accountant.md
+++ b/docs/jobs/trades/accountant.md
@@ -208,4 +208,5 @@ So, gather your resources, refine your accounting skills, and set forth on this 
 ## Passed the Exam? Now What?
 It is recommended that you get the Entrepreneur guide and register a business on the Business Portal subforum or look for a company who is in need of one of the above accountant roles!
 
+- For more info, read the [Making Money Guide](https://wiki.democracycraft.net/government/money/).
 - Find a player-owned company to work for with the DC #employment channel: [DC Employment](https://discord.gg/democracy)

--- a/docs/jobs/trades/contractor.md
+++ b/docs/jobs/trades/contractor.md
@@ -38,4 +38,5 @@ Utilizing **DC Jobs** can be a valuable resource for both advertising your servi
 
 If you've successfully passed the exam to become a certified contractor, you might want to explore the Entrepreneur guide. This guide can help you navigate the process of registering a business on the Business Portal subforum. Alternatively, you can seek out existing companies that require your contractor skills.
 
+- For more detailed information, consider reading the [Making Money Guide](https://wiki.democracycraft.net/government/money/).
 - To discover job opportunities and connect with potential clients and employees, be sure to check out DC #employment channel: [DC Employment](https://discord.gg/democracy)

--- a/docs/jobs/trades/contractor.md
+++ b/docs/jobs/trades/contractor.md
@@ -38,6 +38,4 @@ Utilizing **DC Jobs** can be a valuable resource for both advertising your servi
 
 If you've successfully passed the exam to become a certified contractor, you might want to explore the Entrepreneur guide. This guide can help you navigate the process of registering a business on the Business Portal subforum. Alternatively, you can seek out existing companies that require your contractor skills.
 
-For more detailed information, consider reading the [Making Money Guide](https://democracycraft.net/threads/making-money.1410/).
-
-To discover job opportunities and connect with potential clients and employees, be sure to check out DC Jobs on [Discord](https://discord.gg/Q8rNjddjjh).
+- To discover job opportunities and connect with potential clients and employees, be sure to check out DC #employment channel: [DC Employment](https://discord.gg/democracy)

--- a/docs/jobs/trades/farmer.md
+++ b/docs/jobs/trades/farmer.md
@@ -51,7 +51,7 @@ If you've passed your Farmer exam, here are your next steps:
 
 For more detailed information on making money, you can refer to the Making Money Guide.
 
-Additionally, you can find job opportunities and connect with potential employers through DC Jobs: [Join the DC Jobs Discord here](https://discord.gg/Q8rNjddjjh).
+- Additionally, you can find job opportunities and connect with potential employers through DC #employment channel: [DC Employment](https://discord.gg/democracy)
 
 **Farmer Recipes**
 

--- a/docs/jobs/trades/fisherman.md
+++ b/docs/jobs/trades/fisherman.md
@@ -26,3 +26,5 @@ As a Fisherman, you also have the opportunity to capture certain animals followi
 ## Passed the Exam? What Now?
 
 - After passing the exam, it's recommended that you purchase a plot and set up a store, or rent a shop to sell your catches. Alternatively, you can seek employment with companies through DC #employment channel: [DC Employment](https://discord.gg/democracy)
+
+For more detailed information, you can refer to the [Making Money Guide.](https://wiki.democracycraft.net/government/money/)

--- a/docs/jobs/trades/fisherman.md
+++ b/docs/jobs/trades/fisherman.md
@@ -25,7 +25,4 @@ As a Fisherman, you also have the opportunity to capture certain animals followi
 
 ## Passed the Exam? What Now?
 
-After passing the exam, it's recommended that you purchase a plot and set up a store, or rent a shop to sell your catches. Alternatively, you can seek employment with companies through DC Jobs:
-[Join the DC Jobs Discord here.](https://discord.gg/Q8rNjddjjh)
-
-For more detailed information, you can refer to the Making Money Guide.
+- After passing the exam, it's recommended that you purchase a plot and set up a store, or rent a shop to sell your catches. Alternatively, you can seek employment with companies through DC #employment channel: [DC Employment](https://discord.gg/democracy)

--- a/docs/jobs/trades/hunter.md
+++ b/docs/jobs/trades/hunter.md
@@ -24,7 +24,7 @@ After passing the exam, it's recommended that Hunters set up farms to generate i
 - [Skeleton/Zombie Farm](https://www.youtube.com/watch?v=dQUwA2AikHo)
 - [Slime Farm](https://www.youtube.com/watch?v=X1mRLDpoiOk)
 
-For more information, you can refer to the [Mob Egg Capturing Guide](https://wiki.democracycraft.net/features/mobeggs).
+For more information, you can refer to the [Making Money Guide](https://wiki.democracycraft.net/government/money/) or the [Mob Egg Capturing Guide](https://wiki.democracycraft.net/features/mobeggs).
 
 ## Hunter Recipes
 

--- a/docs/jobs/trades/hunter.md
+++ b/docs/jobs/trades/hunter.md
@@ -24,7 +24,7 @@ After passing the exam, it's recommended that Hunters set up farms to generate i
 - [Skeleton/Zombie Farm](https://www.youtube.com/watch?v=dQUwA2AikHo)
 - [Slime Farm](https://www.youtube.com/watch?v=X1mRLDpoiOk)
 
-For more information, you can refer to the [Making Money Guide](https://democracycraft.net/threads/making-money.1410/) or the [Mob Egg Capturing Guide](https://www.democracycraft.net/threads/mob-egg-capturing.9644/).
+For more information, you can refer to the [Mob Egg Capturing Guide](https://wiki.democracycraft.net/features/mobeggs).
 
 ## Hunter Recipes
 

--- a/docs/jobs/trades/journalist.md
+++ b/docs/jobs/trades/journalist.md
@@ -52,6 +52,4 @@ If you enjoy writing and publishing, this job is tailored for you.
 
 After passing the exam, it's recommended to find a plot for your shop, rent one, or create a Discord server to operate your journalism business. The Department of Education and Commerce wishes you the best of luck.
 
-For more information on making money, check the [Making Money Guide](https://democracycraft.net/threads/making-money.1410/).
-
-You can explore job opportunities with DC Jobs: [Join the DC Jobs Discord here](https://discord.gg/Q8rNjddjjh).
+- You can explore job opportunities with DC #employment channel: [DC Employment](https://discord.gg/democracy)

--- a/docs/jobs/trades/journalist.md
+++ b/docs/jobs/trades/journalist.md
@@ -52,4 +52,5 @@ If you enjoy writing and publishing, this job is tailored for you.
 
 After passing the exam, it's recommended to find a plot for your shop, rent one, or create a Discord server to operate your journalism business. The Department of Education and Commerce wishes you the best of luck.
 
+- For more information on making money, check the [Making Money Guide](https://wiki.democracycraft.net/government/money/).
 - You can explore job opportunities with DC #employment channel: [DC Employment](https://discord.gg/democracy)

--- a/docs/jobs/trades/lumberjack.md
+++ b/docs/jobs/trades/lumberjack.md
@@ -26,6 +26,8 @@ To gather resources, you can either buy them from player shops or obtain them in
 
 (Use /map to find specific biomes).
 
+For more information, read the [Making Money Guide](https://wiki.democracycraft.net/government/money/)
+
 You can also explore job opportunities with DC #employment channel: [DC Employment](https://discord.gg/democracy)
 
 ## Crafting Recipes

--- a/docs/jobs/trades/lumberjack.md
+++ b/docs/jobs/trades/lumberjack.md
@@ -26,9 +26,7 @@ To gather resources, you can either buy them from player shops or obtain them in
 
 (Use /map to find specific biomes).
 
-For more information, read the [Making Money Guide](https://democracycraft.net/threads/making-money.1410/).
-
-You can also explore job opportunities with DC Jobs: [Join the DC Jobs Discord Server](https://discord.gg/Q8rNjddjjh).
+You can also explore job opportunities with DC #employment channel: [DC Employment](https://discord.gg/democracy)
 
 ## Crafting Recipes
 

--- a/docs/jobs/trades/miner.md
+++ b/docs/jobs/trades/miner.md
@@ -44,5 +44,4 @@ As a Miner, your main role is to mine ores, such as coal and netherite, and sell
 
 ## Additional Resources
 
-- To find more ways to make money, read the [Making Money Guide](https://democracycraft.net/threads/making-money.1410/).
-- You can also explore job opportunities with DC Jobs: [Join the DC Jobs Discord Server!](https://discord.gg/Q8rNjddjjh)
+You can explore job opportunities with DC #employment channel: [DC Employment](https://discord.gg/democracy)

--- a/docs/jobs/trades/miner.md
+++ b/docs/jobs/trades/miner.md
@@ -43,5 +43,5 @@ As a Miner, your main role is to mine ores, such as coal and netherite, and sell
 </details>
 
 ## Additional Resources
-
-You can explore job opportunities with DC #employment channel: [DC Employment](https://discord.gg/democracy)
+- To find more ways to make money, read the [Making Money Guide](https://wiki.democracycraft.net/government/money/).
+- You can explore job opportunities with DC #employment channel: [DC Employment](https://discord.gg/democracy)


### PR DESCRIPTION
MinecraftCitiesNetwork/Bugs/issues/83 

This covers everything but the `Legal Affairs` section

This does **not** fix dead image links, this PR only covers hyperlinks.

~~* Money Making guide removed, I did not see a direct alternative.~~
* Job-guide was replaced/removed to link to the Jobs section where the player can read about each job.
* DC Jobs guild replaced with Links/Suggestions to DC discord #employment channel
* RBA guild link updated
* Anything else was linked to its applicable current guide.

`Legal Affairs` does not current have up-to-date policies on the forums, so I've opted to keep it as-is for now.